### PR TITLE
Fix Dockerfile to support cassandra 2.1.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update
 RUN echo "deb http://debian.datastax.com/community stable main" | sudo tee -a /etc/apt/sources.list.d/datastax.sources.list
 RUN curl -L http://debian.datastax.com/debian/repo_key | sudo apt-key add -
 RUN apt-get update
-RUN apt-get install -y dsc20 datastax-agent
+RUN apt-get install -y dsc21 datastax-agent
 
 # Start the datastax-agent
 RUN service datastax-agent start


### PR DESCRIPTION
As is, a docker build command resulted in the following error:

The following packages have unmet dependencies:
 dsc20 : Depends: cassandra (= 2.0.15) but 2.1.5 is to be installed
E: Unable to correct problems, you have held broken packages.

The fix to the Dockerfile seemed to get past this.  I am a total noob at this so I am not sure if it should be merged.  Just wanted to share what I learned in using your repo.

Great work, btw.  Saved me a ton of time.
